### PR TITLE
Create tech-themed anniversary check-in map

### DIFF
--- a/checkin_map.svg
+++ b/checkin_map.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Anniversary Check-in Map (科技感) -->
+<svg width="1000" height="1000" viewBox="0 0 1000 1000" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <!-- Background -->
+  <rect x="0" y="0" width="1000" height="1000" fill="#0B0D14" />
+
+  <!-- Grid lines -->
+  <g stroke="#1F2933" stroke-width="1">
+    <!-- Vertical lines -->
+    <!-- 0 to 1000 every 100 -->
+    <path d="M100 0 V1000" />
+    <path d="M200 0 V1000" />
+    <path d="M300 0 V1000" />
+    <path d="M400 0 V1000" />
+    <path d="M500 0 V1000" />
+    <path d="M600 0 V1000" />
+    <path d="M700 0 V1000" />
+    <path d="M800 0 V1000" />
+    <path d="M900 0 V1000" />
+    <!-- Horizontal lines -->
+    <path d="M0 100 H1000" />
+    <path d="M0 200 H1000" />
+    <path d="M0 300 H1000" />
+    <path d="M0 400 H1000" />
+    <path d="M0 500 H1000" />
+    <path d="M0 600 H1000" />
+    <path d="M0 700 H1000" />
+    <path d="M0 800 H1000" />
+    <path d="M0 900 H1000" />
+  </g>
+
+  <!-- Paths connecting the nodes (dashed) -->
+  <g stroke="#08F7FE" stroke-width="2" stroke-dasharray="8 6" fill="none">
+    <polyline points="100,100 800,150 200,500 700,600 400,900" />
+  </g>
+
+  <!-- Activity nodes -->
+  <g fill="#08F7FE" stroke="white" stroke-width="2">
+    <!-- 粘币游戏 -->
+    <circle cx="100" cy="100" r="20" />
+    <!-- 淘趣循环市集 -->
+    <circle cx="800" cy="150" r="20" />
+    <!-- 框住时光·与你同行 -->
+    <circle cx="200" cy="500" r="20" />
+    <!-- 快问快答 -->
+    <circle cx="700" cy="600" r="20" />
+    <!-- 量子纠缠瓶 -->
+    <circle cx="400" cy="900" r="20" />
+  </g>
+
+  <!-- Labels -->
+  <g font-family="Arial, sans-serif" font-size="28" fill="white" text-anchor="middle">
+    <text x="100" y="70">粘币游戏</text>
+    <text x="800" y="120">淘趣循环市集</text>
+    <text x="200" y="470">框住时光·与你同行</text>
+    <text x="700" y="570">快问快答</text>
+    <text x="400" y="870">量子纠缠瓶</text>
+  </g>
+
+  <!-- Stamp area -->
+  <g stroke="#F50157" stroke-width="3" stroke-dasharray="12 8" fill="none">
+    <rect x="800" y="800" width="200" height="200" />
+  </g>
+  <text x="900" y="910" font-family="Arial, sans-serif" font-size="32" fill="#F50157" text-anchor="middle" dominant-baseline="middle">盖章区</text>
+</svg>

--- a/generate_checkin_map.py
+++ b/generate_checkin_map.py
@@ -1,0 +1,116 @@
+import matplotlib.pyplot as plt
+from matplotlib.patches import Circle, Rectangle
+
+# ============================
+# Anniversary Check-in Map Generator
+# ============================
+# This script creates a tech-style check-in map (PNG) with
+# 1) A dark grid background
+# 2) Five activity locations
+# 3) A reserved stamp area (盖章区)
+# ----------------------------------
+# Output: checkin_map.png in the same directory
+# ----------------------------------
+
+
+def draw_checkin_map(output_path: str = "checkin_map.png"):
+    """Generate the anniversary check-in map and save to *output_path*."""
+
+    # Figure setup (A4 ratio ~ 11.69 x 8.27 inches)
+    fig, ax = plt.subplots(figsize=(11.69, 8.27), dpi=300)
+
+    # Tech-style color palette
+    bg_color = "#0B0D14"       # Deep navy background
+    grid_color = "#1F2933"     # Subtle grid lines
+    accent = "#08F7FE"         # Neon cyan accents
+    danger = "#F50157"         # Magenta-red highlight (stamp area)
+
+    # Apply background color
+    fig.patch.set_facecolor(bg_color)
+    ax.set_facecolor(bg_color)
+
+    # Draw grid (10x10)
+    for x in range(0, 101, 10):
+        ax.axvline(x=x, color=grid_color, linewidth=0.3, zorder=0)
+    for y in range(0, 101, 10):
+        ax.axhline(y=y, color=grid_color, linewidth=0.3, zorder=0)
+
+    # Activity locations & coordinates (0-100 virtual canvas)
+    locations = {
+        "粘币游戏": (10, 90),
+        "淘趣循环市集": (80, 85),
+        "框住时光·与你同行": (20, 50),
+        "快问快答": (70, 40),
+        "量子纠缠瓶": (40, 10),
+    }
+
+    # Draw nodes and labels
+    for name, (x, y) in locations.items():
+        ax.add_patch(Circle((x, y), 3, facecolor=accent, edgecolor="white", linewidth=0.8, zorder=3))
+        ax.text(
+            x,
+            y - 5,
+            name,
+            color="white",
+            fontsize=9,
+            ha="center",
+            va="top",
+            zorder=4,
+        )
+
+    # Connect nodes with dashed path in visiting order
+    path_order = [
+        "粘币游戏",
+        "淘趣循环市集",
+        "框住时光·与你同行",
+        "快问快答",
+        "量子纠缠瓶",
+    ]
+    for i in range(len(path_order) - 1):
+        x1, y1 = locations[path_order[i]]
+        x2, y2 = locations[path_order[i + 1]]
+        ax.plot(
+            [x1, x2],
+            [y1, y2],
+            color=accent,
+            linewidth=0.6,
+            linestyle="--",
+            zorder=2,
+        )
+
+    # Reserved stamp area (bottom-right)
+    stamp_rect = Rectangle(
+        (80, 0),
+        20,
+        20,
+        linewidth=1.5,
+        edgecolor=danger,
+        facecolor="none",
+        linestyle="--",
+        zorder=5,
+    )
+    ax.add_patch(stamp_rect)
+    ax.text(
+        90,
+        10,
+        "盖章区",
+        color=danger,
+        fontsize=10,
+        ha="center",
+        va="center",
+        zorder=6,
+    )
+
+    # Final plot aesthetics
+    ax.set_xlim(0, 100)
+    ax.set_ylim(0, 100)
+    ax.axis("off")
+    plt.tight_layout()
+
+    # Save the image (include figure facecolor)
+    plt.savefig(output_path, dpi=300, facecolor=fig.get_facecolor())
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    draw_checkin_map()


### PR DESCRIPTION
Add `generate_checkin_map.py` to create a tech-themed anniversary check-in map with specified locations and a stamp area.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a4ee081-6a66-48ae-9863-5e2af3e09c0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a4ee081-6a66-48ae-9863-5e2af3e09c0e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

